### PR TITLE
[#24] 애그리거트 기준으로 도메인 패키지 구조 변경

### DIFF
--- a/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
+++ b/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
@@ -6,7 +6,7 @@ import com.srltas.runtogether.application.mappper.LocationNeighborhoodVerifyRequ
 import com.srltas.runtogether.application.mappper.UserNeighborhoodVerifyRequestMapper;
 import com.srltas.runtogether.domain.exception.NeighborhoodNotFoundException;
 import com.srltas.runtogether.domain.exception.OutOfNeighborhoodBoundaryException;
-import com.srltas.runtogether.domain.model.location.Location;
+import com.srltas.runtogether.domain.model.neighborhood.Location;
 import com.srltas.runtogether.domain.model.neighborhood.Neighborhood;
 import com.srltas.runtogether.domain.model.neighborhood.NeighborhoodRepository;
 import com.srltas.runtogether.domain.model.user.User;

--- a/src/main/java/com/srltas/runtogether/application/mappper/LocationNeighborhoodVerifyRequestMapper.java
+++ b/src/main/java/com/srltas/runtogether/application/mappper/LocationNeighborhoodVerifyRequestMapper.java
@@ -1,7 +1,7 @@
 package com.srltas.runtogether.application.mappper;
 
 import com.srltas.runtogether.adapter.in.LocationNeighborhoodVerifyRequest;
-import com.srltas.runtogether.domain.model.location.Location;
+import com.srltas.runtogether.domain.model.neighborhood.Location;
 
 public class LocationNeighborhoodVerifyRequestMapper {
 

--- a/src/main/java/com/srltas/runtogether/domain/model/neighborhood/Location.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/neighborhood/Location.java
@@ -1,6 +1,6 @@
-package com.srltas.runtogether.domain.model.location;
+package com.srltas.runtogether.domain.model.neighborhood;
 
-import static com.srltas.runtogether.domain.model.location.LocationUtils.*;
+import static com.srltas.runtogether.domain.model.neighborhood.LocationUtils.*;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/src/main/java/com/srltas/runtogether/domain/model/neighborhood/LocationUtils.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/neighborhood/LocationUtils.java
@@ -1,4 +1,4 @@
-package com.srltas.runtogether.domain.model.location;
+package com.srltas.runtogether.domain.model.neighborhood;
 
 import lombok.experimental.UtilityClass;
 

--- a/src/main/java/com/srltas/runtogether/domain/model/neighborhood/Neighborhood.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/neighborhood/Neighborhood.java
@@ -1,7 +1,5 @@
 package com.srltas.runtogether.domain.model.neighborhood;
 
-import com.srltas.runtogether.domain.model.location.Location;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/srltas/runtogether/application/NeighborhoodVerificationServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/application/NeighborhoodVerificationServiceTest.java
@@ -25,8 +25,8 @@ import com.srltas.runtogether.application.mappper.LocationNeighborhoodVerifyRequ
 import com.srltas.runtogether.application.mappper.UserNeighborhoodVerifyRequestMapper;
 import com.srltas.runtogether.domain.exception.NeighborhoodNotFoundException;
 import com.srltas.runtogether.domain.exception.OutOfNeighborhoodBoundaryException;
-import com.srltas.runtogether.domain.model.location.Location;
-import com.srltas.runtogether.domain.model.location.LocationUtils;
+import com.srltas.runtogether.domain.model.neighborhood.Location;
+import com.srltas.runtogether.domain.model.neighborhood.LocationUtils;
 import com.srltas.runtogether.domain.model.neighborhood.Neighborhood;
 import com.srltas.runtogether.domain.model.neighborhood.NeighborhoodRepository;
 import com.srltas.runtogether.domain.model.user.User;

--- a/src/test/java/com/srltas/runtogether/domain/model/neighborhood/LocationUtilsTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/neighborhood/LocationUtilsTest.java
@@ -1,6 +1,6 @@
-package com.srltas.runtogether.domain.model.location;
+package com.srltas.runtogether.domain.model.neighborhood;
 
-import static com.srltas.runtogether.domain.model.location.LocationUtils.*;
+import static com.srltas.runtogether.domain.model.neighborhood.LocationUtils.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 

--- a/src/test/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodTest.java
@@ -1,6 +1,6 @@
 package com.srltas.runtogether.domain.model.neighborhood;
 
-import static com.srltas.runtogether.domain.model.location.LocationUtils.*;
+import static com.srltas.runtogether.domain.model.neighborhood.LocationUtils.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.*;
@@ -11,9 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.srltas.runtogether.domain.model.location.Location;
-import com.srltas.runtogether.domain.model.location.LocationUtils;
 
 @ExtendWith(MockitoExtension.class)
 class NeighborhoodTest {


### PR DESCRIPTION
## 📌 Summary
도메인 패키지 구조를 애그리거트 기준으로 재구성하여 User와 Neighborhood 애그리거트를 분리합니다. 이를 통해 애그리거트 간 경계를 명확히 하고 각 애그리거트의 응집성을 강화했습니다.

## 📝 Description
User와 Neighborhood로 애그리거트 분리 이유
- User는 사용자의 동네 인증 정보를 관리하며, Neighborhood는 특정 동네의 경계와 위치 정보를 다룹니다. 따라서, 각 애그리거트가 서로의 상태에 직접적으로 의존하거나 관리할 필요가 없고, 애그리거트 간 경계를 명확히 하여 각자의 일관성을 유지할 수 있도록 분리했습니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
