### PR TITLE
[#28] 동네 인증 Controller 구현 및 Service 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
@@ -1,0 +1,36 @@
+package com.srltas.runtogether.adapter.in;
+
+import static com.srltas.runtogether.adapter.in.web.dto.mapper.NeighborhoodVerificationMapper.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+import com.srltas.runtogether.adapter.in.web.dto.NeighborhoodVerificationRequest;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationCommand;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class NeighborhoodVerificationController {
+
+	private final NeighborhoodVerificationUseCase neighborhoodVerificationUseCase;
+
+	@PostMapping("/neighborhood/verification")
+	public ResponseEntity<NeighborhoodVerificationResponse> verifyNeighborhood(
+		@RequestBody @Valid NeighborhoodVerificationRequest neighborhoodVerificationRequest,
+		@SessionAttribute(name = "login_user_id", required = false) Long userId) {
+		NeighborhoodVerificationCommand neighborhoodVerificationCommand = toCommand(neighborhoodVerificationRequest);
+
+		NeighborhoodVerificationResponse response = neighborhoodVerificationUseCase.verifyAndRegisterNeighborhood(
+			userId, neighborhoodVerificationCommand);
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
@@ -1,8 +1,22 @@
 package com.srltas.runtogether.adapter.in.web.dto;
 
+import org.hibernate.validator.constraints.Range;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record NeighborhoodVerificationRequest(
+
+	@NotNull
+	@Range(min = -90, max = 90, message="위도는 -90에서 90 사이여야 합니다.")
 	double latitude,
+
+	@NotNull
+	@Range(min = -180, max = 180, message="경도는 -180에서 180 사이여야 합니다.")
 	double longitude,
+
+	@NotNull
+	@PositiveOrZero(message = "동네 ID는 0 이상의 값이어야 합니다.")
 	int neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
+++ b/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
@@ -2,7 +2,13 @@ package com.srltas.runtogether.application;
 
 import static com.srltas.runtogether.application.mappper.LocationMapper.*;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationCommand;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
 import com.srltas.runtogether.domain.exception.NeighborhoodNotFoundException;
 import com.srltas.runtogether.domain.exception.OutOfNeighborhoodBoundaryException;
@@ -14,6 +20,7 @@ import com.srltas.runtogether.domain.model.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Service
 @RequiredArgsConstructor
 public class NeighborhoodVerificationService implements NeighborhoodVerificationUseCase {
 
@@ -21,7 +28,8 @@ public class NeighborhoodVerificationService implements NeighborhoodVerification
 	private final UserRepository userRepository;
 
 	@Override
-	public void verifyAndRegisterNeighborhood(long userId, NeighborhoodVerificationCommand command) {
+	public NeighborhoodVerificationResponse verifyAndRegisterNeighborhood(long userId,
+		NeighborhoodVerificationCommand command) {
 		Neighborhood neighborhood = neighborhoodRepository.findById(command.neighborhoodId())
 			.orElseThrow(NeighborhoodNotFoundException::new);
 
@@ -31,6 +39,12 @@ public class NeighborhoodVerificationService implements NeighborhoodVerification
 			User user = userRepository.findById(userId);
 			user.addVerifiedNeighborhood(neighborhood);
 			userRepository.save(user);
+
+			return NeighborhoodVerificationResponse.builder()
+				.verifyId(UUID.randomUUID().toString())
+				.verified(true)
+				.verificationTime(LocalDateTime.now().toString())
+				.build();
 		} else {
 			throw new OutOfNeighborhoodBoundaryException();
 		}

--- a/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationResponse.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationResponse.java
@@ -1,0 +1,11 @@
+package com.srltas.runtogether.application.port.in;
+
+import lombok.Builder;
+
+@Builder
+public record NeighborhoodVerificationResponse(
+	String verifyId,
+	boolean verified,
+	String verificationTime
+) {
+}

--- a/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationUseCase.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationUseCase.java
@@ -1,5 +1,6 @@
 package com.srltas.runtogether.application.port.in;
 
 public interface NeighborhoodVerificationUseCase {
-	void verifyAndRegisterNeighborhood(long userId, NeighborhoodVerificationCommand neighborhoodVerificationCommand);
+	NeighborhoodVerificationResponse verifyAndRegisterNeighborhood(long userId,
+		NeighborhoodVerificationCommand neighborhoodVerificationCommand);
 }

--- a/src/main/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodRepository.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodRepository.java
@@ -2,6 +2,9 @@ package com.srltas.runtogether.domain.model.neighborhood;
 
 import java.util.Optional;
 
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface NeighborhoodRepository {
 	Optional<Neighborhood> findById(int neighborhoodId);
 }

--- a/src/main/java/com/srltas/runtogether/domain/model/user/UserRepository.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/user/UserRepository.java
@@ -1,5 +1,8 @@
 package com.srltas.runtogether.domain.model.user;
 
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface UserRepository {
 	User findById(long id);
 	void save(User user);

--- a/src/test/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationControllerTest.java
@@ -1,0 +1,65 @@
+package com.srltas.runtogether.adapter.in;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.srltas.runtogether.adapter.in.web.dto.NeighborhoodVerificationRequest;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationCommand;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
+
+@ExtendWith(MockitoExtension.class)
+class NeighborhoodVerificationControllerTest {
+
+	@Mock
+	private NeighborhoodVerificationUseCase neighborhoodVerificationUseCase;
+
+	@InjectMocks
+	private NeighborhoodVerificationController neighborhoodVerificationController;
+
+	@ParameterizedTest
+	@MethodSource("provideNeighborhoodVerificationRequests")
+	@DisplayName("verifyNeighborhood 메서드에 대한 Parameterized 테스트")
+	void verifyNeighborhood_ShouldReturnOkResponse(NeighborhoodVerificationRequest request, Long userId) {
+		// given
+		NeighborhoodVerificationCommand command = new NeighborhoodVerificationCommand(request.latitude(),
+			request.longitude(), request.neighborhoodId());
+		NeighborhoodVerificationResponse expectedResponse = new NeighborhoodVerificationResponse(
+			UUID.randomUUID().toString(), true, LocalDateTime.now().toString());
+
+		given(neighborhoodVerificationUseCase.verifyAndRegisterNeighborhood(userId, command)).willReturn(
+			expectedResponse);
+
+		// when
+		ResponseEntity<NeighborhoodVerificationResponse> response = neighborhoodVerificationController.verifyNeighborhood(
+			request, userId);
+
+		// then
+		verify(neighborhoodVerificationUseCase).verifyAndRegisterNeighborhood(userId, command);
+		assertThat(response.getStatusCode(), is(HttpStatus.OK));
+		assertThat(response.getBody(), is(expectedResponse));
+	}
+
+	static Stream<Arguments> provideNeighborhoodVerificationRequests() {
+		return Stream.of(
+			Arguments.of(new NeighborhoodVerificationRequest(37.579617, 126.977041, 1), 100L),
+			Arguments.of(new NeighborhoodVerificationRequest(37.556201, 126.972286, 2), 101L),
+			Arguments.of(new NeighborhoodVerificationRequest(37.497911, 127.027618, 3), 102L));
+	}
+}


### PR DESCRIPTION
## 📌 Summary
- 동네 인증 결과를 반환하는 `NeighborhoodVerificationResponse`를 추가하고, 새로운 동네 인증 Controller를 구현했습니다.

## 📝 Description
1. Controller 구현
   - POST로 동네 인증 요청 구현
   - Session에 user id 값을 얻어서 사용하는 방식으로 구현
2. Service, Repository 리팩토링
   - NeighborhoodVerificationResponse를 반환하도록 수정
   - `@Service`, `@Repository`를 붙여 Spring의 의존주입을 받을 수 있도록 수정
3. 동네 인증 테스트 코드 작성
   - Parameterize를 사용해 여러 개의 파라미터 값을 검증할 수 있도록 구현
 
## 📚 References
- [동네 인증 API 문서](https://github.com/f-lab-edu/run-together/wiki/run%E2%80%90together-API)

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
