### PR TITLE
[#33] Springdoc OpenAPI 적용을 통한 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// OpenAPI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.34'
 	annotationProcessor 'org.projectlombok:lombok:1.18.34'

--- a/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
@@ -13,19 +13,29 @@ import com.srltas.runtogether.application.port.in.NeighborhoodVerificationComman
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "동네 인증", description = "동네 인증과 관련된 API")
 @RestController
 @RequiredArgsConstructor
 public class NeighborhoodVerificationController {
 
 	private final NeighborhoodVerificationUseCase neighborhoodVerificationUseCase;
 
+	@Operation(
+		summary = "동네 인증",
+		description = "사용자의 현재 위치를 기반으로 인증받고자 하는 동네 범위 안에 있는지 검증하고, 성공 시 해당 동네를 인증 동네로 등록합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "동네 인증 성공")
 	@PostMapping("/neighborhood/verification")
 	public ResponseEntity<NeighborhoodVerificationResponse> verifyNeighborhood(
 		@RequestBody @Valid NeighborhoodVerificationRequest neighborhoodVerificationRequest,
-		@SessionAttribute(name = "login_user_id", required = false) Long userId) {
+		@Parameter(hidden = true) @SessionAttribute(name = "login_user_id", required = false) Long userId) {
 		NeighborhoodVerificationCommand neighborhoodVerificationCommand = toCommand(neighborhoodVerificationRequest);
 
 		NeighborhoodVerificationResponse response = neighborhoodVerificationUseCase.verifyAndRegisterNeighborhood(

--- a/src/main/java/com/srltas/runtogether/config/OpenAPIConfig.java
+++ b/src/main/java/com/srltas/runtogether/config/OpenAPIConfig.java
@@ -1,0 +1,20 @@
+package com.srltas.runtogether.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class OpenAPIConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.info(new Info()
+				.title("Run Together API")
+				.description("Run Together 프로젝트에서 사용되는 API 명세서")
+				.version("0.0.1"));
+	}
+}


### PR DESCRIPTION
## 📌 Summary
Springdoc OpenAPI를 도입하여 API 문서화를 하고자 합니다. 이를 통해 API 요청 및 응답 구조를 명확하게 확인할 수 있으며, 개발자가 쉽게 엔드포인트를 테스트할 수 있는 환경을 제공합니다.

## 📝 Description
- springdoc-openapi-starter-webmvc-ui 의존성 추가
- Controller에 OpenAPI 어노테이션 추가(`@Tag`,`@Operation`,`@ApiResponse`)
- Swagger UI를 통한 API 명세서 및 테스트 환경 구성

### OpenAPI 화면 예시
index 화면
![OpenAPI_home](https://github.com/user-attachments/assets/f1e92e95-617f-41dc-9820-accd4e6d2ee3)

동네 인증 API 상세 화면
![OpenAPI_동네인증](https://github.com/user-attachments/assets/1698afe0-ad38-4348-8e07-f4dbf565212e)



## 📚 References
[Springdoc OpenAPI 공식 문서](https://springdoc.org/)

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
