### PR TITLE
[#41] 서비스에서 Optional<User> 처리 로직 추가

### DIFF
--- a/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
+++ b/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
@@ -12,6 +12,7 @@ import com.srltas.runtogether.application.port.in.NeighborhoodVerificationRespon
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
 import com.srltas.runtogether.domain.exception.NeighborhoodNotFoundException;
 import com.srltas.runtogether.domain.exception.OutOfNeighborhoodBoundaryException;
+import com.srltas.runtogether.domain.exception.UserNotFoundException;
 import com.srltas.runtogether.domain.model.neighborhood.Location;
 import com.srltas.runtogether.domain.model.neighborhood.Neighborhood;
 import com.srltas.runtogether.domain.model.neighborhood.NeighborhoodRepository;
@@ -36,8 +37,9 @@ public class NeighborhoodVerificationService implements NeighborhoodVerification
 		Location currentLocation = neighborhoodVerificationCommandToDomain(command);
 
 		if (neighborhood.isWithinBoundary(currentLocation)) {
-			User user = userRepository.findById(userId);
-			user.addVerifiedNeighborhood(neighborhood);
+			User user = userRepository.findById(userId)
+					.orElseThrow(UserNotFoundException::new);
+			user.verifiedNeighborhood(neighborhood.getId());
 			userRepository.save(user);
 
 			return NeighborhoodVerificationResponse.builder()


### PR DESCRIPTION
## 📌 Summary
UserRepository.findById 메서드에서 Optional<User>로 반환된 값을 서비스 레이어에서 적절히 처리하도록 변경합니다.

## 📝 Description
findById 메서드가 Optional<User>를 반환하도록 변경된 이후에도, 서비스 레이어에서 반환값을 Optional로 처리하지 않고 User 타입으로 직접 사용하던 문제를 해결했습니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
