### PR TITLE
[#44] MySQL, MyBatis 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,10 @@
 # Compiled class files
 *.class
 
-# Log files
+### Log files ###
 *.log
 
-# Package files
+### Package files ###
 *.jar
 *.war
 *.nar
@@ -26,3 +26,6 @@
 ### Gradle ###
 .gradle
 **/build/
+
+### Local DB connection settings ###
+/src/main/resources/db-config.yml

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,15 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// MyBatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// OpenAPI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=runtogether

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: runtogether
+  config:
+    import: db-config.yml
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+mybatis:
+  mapper-locations: classpath:mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
+  type-handlers-package: com.srltas.runtogether.adapter.out.persistence.mybatis
+  type-aliases-package: com.srltas.runtogether.*


### PR DESCRIPTION
## 📌 Summary
데이터베이스 연동을 위해 MySQL과 MyBatis을 설정하는 작업입니다.

## 📝 Description
- MySQL, MyBatis을 사용하기 위해 Gradle에 의존성을 추가했습니다.
- application.yml에 MySQL 연결을 위한 설정과 MyBatis 설정을 추가했습니다.
- db-config.yml을 만들어 DB 접속 정보를 따로 관리합니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
