### PR TITLE
[#43] UseCase 응답 객체 이름 변경

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.srltas.runtogether.adapter.in.web.dto.NeighborhoodVerificationRequest;
 import com.srltas.runtogether.adapter.out.session.UserSessionDTO;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationCommand;
-import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResult;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,15 +35,15 @@ public class NeighborhoodVerificationController {
 	)
 	@ApiResponse(responseCode = "200", description = "동네 인증 성공")
 	@PostMapping(NEIGHBORHOOD_VERIFICATION)
-	public ResponseEntity<NeighborhoodVerificationResponse> verifyNeighborhood(
+	public ResponseEntity<NeighborhoodVerificationResult> verifyNeighborhood(
 		@RequestBody @Valid NeighborhoodVerificationRequest neighborhoodVerificationRequest, HttpSession session) {
 		UserSessionDTO userSession = (UserSessionDTO)session.getAttribute(USER_SESSION);
 
 		NeighborhoodVerificationCommand neighborhoodVerificationCommand = toCommand(neighborhoodVerificationRequest);
 
-		NeighborhoodVerificationResponse response = neighborhoodVerificationUseCase.verifyAndRegisterNeighborhood(
+		NeighborhoodVerificationResult result = neighborhoodVerificationUseCase.verifyAndRegisterNeighborhood(
 			userSession.userId(), neighborhoodVerificationCommand);
 
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok(result);
 	}
 }

--- a/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
+++ b/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationCommand;
-import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResult;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
 import com.srltas.runtogether.domain.exception.NeighborhoodNotFoundException;
 import com.srltas.runtogether.domain.exception.OutOfNeighborhoodBoundaryException;
@@ -29,7 +29,7 @@ public class NeighborhoodVerificationService implements NeighborhoodVerification
 	private final UserRepository userRepository;
 
 	@Override
-	public NeighborhoodVerificationResponse verifyAndRegisterNeighborhood(long userId,
+	public NeighborhoodVerificationResult verifyAndRegisterNeighborhood(long userId,
 		NeighborhoodVerificationCommand command) {
 		Neighborhood neighborhood = neighborhoodRepository.findById(command.neighborhoodId())
 			.orElseThrow(NeighborhoodNotFoundException::new);
@@ -42,7 +42,7 @@ public class NeighborhoodVerificationService implements NeighborhoodVerification
 			user.verifiedNeighborhood(neighborhood.getId());
 			userRepository.save(user);
 
-			return NeighborhoodVerificationResponse.builder()
+			return NeighborhoodVerificationResult.builder()
 				.verifyId(UUID.randomUUID().toString())
 				.verified(true)
 				.verificationTime(LocalDateTime.now().toString())

--- a/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationResult.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationResult.java
@@ -3,7 +3,7 @@ package com.srltas.runtogether.application.port.in;
 import lombok.Builder;
 
 @Builder
-public record NeighborhoodVerificationResponse(
+public record NeighborhoodVerificationResult(
 	String verifyId,
 	boolean verified,
 	String verificationTime

--- a/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationUseCase.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationUseCase.java
@@ -1,6 +1,6 @@
 package com.srltas.runtogether.application.port.in;
 
 public interface NeighborhoodVerificationUseCase {
-	NeighborhoodVerificationResponse verifyAndRegisterNeighborhood(long userId,
+	NeighborhoodVerificationResult verifyAndRegisterNeighborhood(long userId,
 		NeighborhoodVerificationCommand neighborhoodVerificationCommand);
 }

--- a/src/test/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.ResponseEntity;
 import com.srltas.runtogether.adapter.in.web.dto.NeighborhoodVerificationRequest;
 import com.srltas.runtogether.adapter.out.session.UserSessionDTO;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationCommand;
-import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResponse;
+import com.srltas.runtogether.application.port.in.NeighborhoodVerificationResult;
 import com.srltas.runtogether.application.port.in.NeighborhoodVerificationUseCase;
 
 import jakarta.servlet.http.HttpSession;
@@ -37,7 +37,7 @@ class NeighborhoodVerificationControllerTest {
 	private HttpSession session;
 
 	@Mock
-	private NeighborhoodVerificationResponse neighborhoodVerificationResponse;
+	private NeighborhoodVerificationResult neighborhoodVerificationResult;
 
 	@InjectMocks
 	private NeighborhoodVerificationController neighborhoodVerificationController;
@@ -49,15 +49,15 @@ class NeighborhoodVerificationControllerTest {
 		// given
 		when(session.getAttribute(USER_SESSION)).thenReturn(userSessionDTO);
 		when(neighborhoodVerificationUseCase.verifyAndRegisterNeighborhood(eq(userSessionDTO.userId()),
-			any(NeighborhoodVerificationCommand.class))).thenReturn(neighborhoodVerificationResponse);
+			any(NeighborhoodVerificationCommand.class))).thenReturn(neighborhoodVerificationResult);
 
 		// when
-		ResponseEntity<NeighborhoodVerificationResponse> response = neighborhoodVerificationController
+		ResponseEntity<NeighborhoodVerificationResult> result = neighborhoodVerificationController
 			.verifyNeighborhood(request, session);
 
 		// then
-		assertThat(response.getStatusCode(), is(HttpStatus.OK));
-		assertThat(response.getBody(), is(neighborhoodVerificationResponse));
+		assertThat(result.getStatusCode(), is(HttpStatus.OK));
+		assertThat(result.getBody(), is(neighborhoodVerificationResult));
 	}
 
 	static Stream<Arguments> provideRequestsForSuccess() {


### PR DESCRIPTION
## 📌 Summary
UseCase에서 응답 객체의 이름을 `Response`에서 `Result`로 변경하여, 웹 계층에 한정된 느낌을 없애고 더 중립적인 이름을 사용했습니다. 이를 통해 응답 객체가 특정 기술에 의존하지 않도록 개선했습니다.

## 📝 Description
`NeighborhoodVerificationResponse` -> `NeighborhoodVerificationResult`
- 컨트롤러, 서비스, 테스트 코드 등 모두 이 변경이 적용되었습니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
