### PR TITLE
[#50] 내 동네 등록 Controller 구현

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationController.java
@@ -1,6 +1,6 @@
 package com.srltas.runtogether.adapter.in;
 
-import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.USER_SESSION;
+import static com.srltas.runtogether.adapter.in.web.common.SessionUtils.*;
 import static com.srltas.runtogether.adapter.in.web.common.UrlConstants.*;
 import static com.srltas.runtogether.adapter.in.web.dto.mapper.NeighborhoodVerificationMapper.*;
 
@@ -37,7 +37,7 @@ public class NeighborhoodVerificationController {
 	@PostMapping(NEIGHBORHOOD_VERIFICATION)
 	public ResponseEntity<NeighborhoodVerificationResult> verifyNeighborhood(
 		@RequestBody @Valid NeighborhoodVerificationRequest neighborhoodVerificationRequest, HttpSession session) {
-		UserSessionDTO userSession = (UserSessionDTO)session.getAttribute(USER_SESSION);
+		UserSessionDTO userSession = getUserSessionDTO(session);
 
 		NeighborhoodVerificationCommand neighborhoodVerificationCommand = toCommand(neighborhoodVerificationRequest);
 

--- a/src/main/java/com/srltas/runtogether/adapter/in/UserNeighborhoodController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/UserNeighborhoodController.java
@@ -2,7 +2,6 @@ package com.srltas.runtogether.adapter.in;
 
 import static com.srltas.runtogether.adapter.in.web.common.SessionUtils.*;
 import static com.srltas.runtogether.adapter.in.web.common.UrlConstants.*;
-import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +38,6 @@ public class UserNeighborhoodController {
 		UserSessionDTO userSession = getUserSessionDTO(session);
 		addUserNeighborhood.addNeighborhood(
 			new AddUserNeighborhoodCommand(userSession.userId(), request.neighborhoodId()));
-		return new ResponseEntity<>(CREATED);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/UserNeighborhoodController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/UserNeighborhoodController.java
@@ -1,0 +1,44 @@
+package com.srltas.runtogether.adapter.in;
+
+import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static com.srltas.runtogether.adapter.in.web.common.UrlConstants.*;
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.srltas.runtogether.adapter.in.web.dto.AddUserNeighborhoodRequest;
+import com.srltas.runtogether.adapter.out.session.UserSessionDTO;
+import com.srltas.runtogether.application.port.in.AddUserNeighborhood;
+import com.srltas.runtogether.application.port.in.AddUserNeighborhoodCommand;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "내 동네 API", description = "내 동네 API")
+@RestController
+@RequiredArgsConstructor
+public class UserNeighborhoodController {
+
+	private final AddUserNeighborhood addUserNeighborhood;
+
+	@Operation(
+		summary = "내 동네 등록",
+		description = "사용자가 특정 동네를 자신의 동네로 등록합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "내 동네 등록 성공")
+	@PostMapping(USER_NEIGHBORHOOD_REGISTRATION)
+	public ResponseEntity<Void> addUserNeighborhood(
+		@RequestBody @Valid AddUserNeighborhoodRequest request, HttpSession session) {
+		UserSessionDTO userSession = (UserSessionDTO)session.getAttribute(USER_SESSION);
+		addUserNeighborhood.addNeighborhood(
+			new AddUserNeighborhoodCommand(userSession.userId(), request.neighborhoodId()));
+		return new ResponseEntity<>(CREATED);
+	}
+}

--- a/src/main/java/com/srltas/runtogether/adapter/in/UserNeighborhoodController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/UserNeighborhoodController.java
@@ -1,6 +1,6 @@
 package com.srltas.runtogether.adapter.in;
 
-import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static com.srltas.runtogether.adapter.in.web.common.SessionUtils.*;
 import static com.srltas.runtogether.adapter.in.web.common.UrlConstants.*;
 import static org.springframework.http.HttpStatus.*;
 
@@ -36,7 +36,7 @@ public class UserNeighborhoodController {
 	@PostMapping(USER_NEIGHBORHOOD_REGISTRATION)
 	public ResponseEntity<Void> addUserNeighborhood(
 		@RequestBody @Valid AddUserNeighborhoodRequest request, HttpSession session) {
-		UserSessionDTO userSession = (UserSessionDTO)session.getAttribute(USER_SESSION);
+		UserSessionDTO userSession = getUserSessionDTO(session);
 		addUserNeighborhood.addNeighborhood(
 			new AddUserNeighborhoodCommand(userSession.userId(), request.neighborhoodId()));
 		return new ResponseEntity<>(CREATED);

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/common/SessionUtils.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/common/SessionUtils.java
@@ -1,0 +1,16 @@
+package com.srltas.runtogether.adapter.in.web.common;
+
+import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+
+import com.srltas.runtogether.adapter.out.session.UserSessionDTO;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class SessionUtils {
+
+	public UserSessionDTO getUserSessionDTO(HttpSession session) {
+		return (UserSessionDTO)session.getAttribute(USER_SESSION);
+	}
+}

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
@@ -8,7 +8,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class UrlConstants {
 	public final String NEIGHBORHOOD_VERIFICATION = "/neighborhood/verification";
-	public final String USER_NEIGHBORHOOD_REGISTRATION = "/user-neighborhood";
+	public final String USER_NEIGHBORHOOD_REGISTRATION = "/users/neighborhoods";
 
 	public List<String> getAuthRequiredUrls() {
 		return Arrays.asList(NEIGHBORHOOD_VERIFICATION, USER_NEIGHBORHOOD_REGISTRATION);

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
@@ -5,4 +5,5 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class UrlConstants {
 	public final String NEIGHBORHOOD_VERIFICATION = "/neighborhood/verification";
+	public final String USER_NEIGHBORHOOD_REGISTRATION = "/user-neighborhood";
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
@@ -1,9 +1,16 @@
 package com.srltas.runtogether.adapter.in.web.common;
 
+import java.util.Arrays;
+import java.util.List;
+
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class UrlConstants {
 	public final String NEIGHBORHOOD_VERIFICATION = "/neighborhood/verification";
 	public final String USER_NEIGHBORHOOD_REGISTRATION = "/user-neighborhood";
+
+	public List<String> getAuthRequiredUrls() {
+		return Arrays.asList(NEIGHBORHOOD_VERIFICATION, USER_NEIGHBORHOOD_REGISTRATION);
+	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.PositiveOrZero;
 public record AddUserNeighborhoodRequest(
 	@NotNull
 	@PositiveOrZero(message = "동네 ID는 0 이상의 값이어야 합니다.")
-	int neighborhoodId
+	Integer neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
@@ -1,0 +1,11 @@
+package com.srltas.runtogether.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record AddUserNeighborhoodRequest(
+	@NotNull
+	@PositiveOrZero(message = "동네 ID는 0 이상의 값이어야 합니다.")
+	int neighborhoodId
+) {
+}

--- a/src/main/java/com/srltas/runtogether/config/WebConfig.java
+++ b/src/main/java/com/srltas/runtogether/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig {
 	public FilterRegistrationBean<AuthenticationFilter> sessionFilterRegistration() {
 		FilterRegistrationBean<AuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
 		registrationBean.setFilter(new AuthenticationFilter(sessionStorage));
-		registrationBean.addUrlPatterns(NEIGHBORHOOD_VERIFICATION, USER_NEIGHBORHOOD_REGISTRATION);
+		registrationBean.setUrlPatterns(getAuthRequiredUrls());
 		registrationBean.setOrder(1);
 		return registrationBean;
 	}

--- a/src/main/java/com/srltas/runtogether/config/WebConfig.java
+++ b/src/main/java/com/srltas/runtogether/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig {
 	public FilterRegistrationBean<AuthenticationFilter> sessionFilterRegistration() {
 		FilterRegistrationBean<AuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
 		registrationBean.setFilter(new AuthenticationFilter(sessionStorage));
-		registrationBean.addUrlPatterns(NEIGHBORHOOD_VERIFICATION);
+		registrationBean.addUrlPatterns(NEIGHBORHOOD_VERIFICATION, USER_NEIGHBORHOOD_REGISTRATION);
 		registrationBean.setOrder(1);
 		return registrationBean;
 	}

--- a/src/test/java/com/srltas/runtogether/adapter/in/UserNeighborhoodControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/UserNeighborhoodControllerTest.java
@@ -1,0 +1,49 @@
+package com.srltas.runtogether.adapter.in;
+
+import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.srltas.runtogether.adapter.in.web.dto.AddUserNeighborhoodRequest;
+import com.srltas.runtogether.adapter.out.session.UserSessionDTO;
+import com.srltas.runtogether.application.port.in.AddUserNeighborhood;
+import com.srltas.runtogether.application.port.in.AddUserNeighborhoodCommand;
+
+import jakarta.servlet.http.HttpSession;
+
+@ExtendWith(MockitoExtension.class)
+class UserNeighborhoodControllerTest {
+
+	@Mock
+	private AddUserNeighborhood addUserNeighborhood;
+
+	@Mock
+	HttpSession session;
+
+	@InjectMocks
+	private UserNeighborhoodController userNeighborhoodController;
+
+	@Test
+	@DisplayName("내 동네 등록 성공")
+	void testAddUserNeighborhoodSuccess() {
+		AddUserNeighborhoodRequest request = new AddUserNeighborhoodRequest(100);
+		UserSessionDTO userSessionDTO = new UserSessionDTO(1L, "user1");
+		given(session.getAttribute(USER_SESSION)).willReturn(userSessionDTO);
+
+		ResponseEntity<Void> response = userNeighborhoodController.addUserNeighborhood(request, session);
+
+		assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
+		verify(addUserNeighborhood).addNeighborhood(
+			new AddUserNeighborhoodCommand(userSessionDTO.userId(), request.neighborhoodId()));
+	}
+}


### PR DESCRIPTION
## 📌 Summary
내 동네 등록 기능에 대한 Controller를 구현했습니다.

## 📝 Description
**내 동네 등록 Controller 추가**
- `/users/neighborhoods` POST 요청을 보내면 내 동네 등록 기능을 수행하도록 만들었습니다.
- 등록에 성공하면 200 응답을 보내도록 만들었습니다.

**필터 설정 수정**
- 내 동네 등록도 로그인 된 사용자만 접근할 수 있도록 필터 설정에 내 동네 등록 URL도 추가했습니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
