### PR TITLE
[#54] 객체 ID 데이터 타입을 String으로 변경

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
@@ -1,9 +1,11 @@
 package com.srltas.runtogether.adapter.in.web.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record AddUserNeighborhoodRequest(
-	@NotNull
+	@NotBlank
+	@Pattern(regexp = "^usr_([a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12})$")
 	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
@@ -1,11 +1,9 @@
 package com.srltas.runtogether.adapter.in.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record AddUserNeighborhoodRequest(
 	@NotBlank
-	@Pattern(regexp = "^usr_([a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12})$")
 	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddUserNeighborhoodRequest.java
@@ -1,11 +1,9 @@
 package com.srltas.runtogether.adapter.in.web.dto;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 
 public record AddUserNeighborhoodRequest(
 	@NotNull
-	@PositiveOrZero(message = "동네 ID는 0 이상의 값이어야 합니다.")
-	Integer neighborhoodId
+	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
@@ -2,7 +2,9 @@ package com.srltas.runtogether.adapter.in.web.dto;
 
 import org.hibernate.validator.constraints.Range;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record NeighborhoodVerificationRequest(
 
@@ -14,7 +16,8 @@ public record NeighborhoodVerificationRequest(
 	@Range(min = -180, max = 180, message="경도는 -180에서 180 사이여야 합니다.")
 	double longitude,
 
-	@NotNull
+	@NotBlank
+	@Pattern(regexp = "^nhb_([a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12})$")
 	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
@@ -3,7 +3,6 @@ package com.srltas.runtogether.adapter.in.web.dto;
 import org.hibernate.validator.constraints.Range;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 
 public record NeighborhoodVerificationRequest(
 
@@ -16,7 +15,6 @@ public record NeighborhoodVerificationRequest(
 	double longitude,
 
 	@NotNull
-	@PositiveOrZero(message = "동네 ID는 0 이상의 값이어야 합니다.")
-	int neighborhoodId
+	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/NeighborhoodVerificationRequest.java
@@ -4,7 +4,6 @@ import org.hibernate.validator.constraints.Range;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 public record NeighborhoodVerificationRequest(
 
@@ -17,7 +16,6 @@ public record NeighborhoodVerificationRequest(
 	double longitude,
 
 	@NotBlank
-	@Pattern(regexp = "^nhb_([a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12})$")
 	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisUserRepository.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisUserRepository.java
@@ -19,7 +19,7 @@ public class MybatisUserRepository implements UserRepository {
 	private final MybatisUserMapper mybatisUserMapper;
 
 	@Override
-	public Optional<User> findById(long id) {
+	public Optional<User> findById(String id) {
 		// TODO 사용자 조회 구현
 		return Optional.empty();
 	}
@@ -30,12 +30,12 @@ public class MybatisUserRepository implements UserRepository {
 	}
 
 	@Override
-	public void addUserNeighborhood(long userId, int neighborhoodId) {
+	public void addUserNeighborhood(String userId, String neighborhoodId) {
 		mybatisUserMapper.addUserNeighborhood(toAddUserNeighborhood(userId, neighborhoodId));
 	}
 
 	@Override
-	public void updateVerifiedUserNeighborhood(long userId, UserNeighborhood userNeighborhood) {
+	public void updateVerifiedUserNeighborhood(String userId, UserNeighborhood userNeighborhood) {
 		mybatisUserMapper.updateVerifiedUserNeighborhood(toVerifiedUserNeighborhoodDAO(userId, userNeighborhood));
 	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/UserConverter.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/UserConverter.java
@@ -9,7 +9,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class UserConverter {
 
-	public AddUserNeighborhoodDAO toAddUserNeighborhood(long userId, int neighborhoodId) {
+	public AddUserNeighborhoodDAO toAddUserNeighborhood(String userId, String neighborhoodId) {
 		return AddUserNeighborhoodDAO.builder()
 			.userId(userId)
 			.neighborhoodId(neighborhoodId)
@@ -18,7 +18,7 @@ public class UserConverter {
 			.build();
 	}
 
-	public VerifiedUserNeighborhoodDAO toVerifiedUserNeighborhoodDAO(long userId, UserNeighborhood userNeighborhood) {
+	public VerifiedUserNeighborhoodDAO toVerifiedUserNeighborhoodDAO(String userId, UserNeighborhood userNeighborhood) {
 		return VerifiedUserNeighborhoodDAO.builder()
 			.userId(userId)
 			.neighborhoodId(userNeighborhood.getNeighborhood().getId())

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/dao/AddUserNeighborhoodDAO.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/dao/AddUserNeighborhoodDAO.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 
 @Builder
 public record AddUserNeighborhoodDAO(
-	long userId,
-	int neighborhoodId,
+	String userId,
+	String neighborhoodId,
 	boolean verified,
 	LocalDateTime verifiedAt
 ) {

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/dao/VerifiedUserNeighborhoodDAO.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/dao/VerifiedUserNeighborhoodDAO.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 
 @Builder
 public record VerifiedUserNeighborhoodDAO(
-	long userId,
-	int neighborhoodId,
+	String userId,
+	String neighborhoodId,
 	boolean verified,
 	LocalDateTime verifiedAt
 ) {

--- a/src/main/java/com/srltas/runtogether/adapter/out/session/SessionStorageImpl.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/session/SessionStorageImpl.java
@@ -1,5 +1,7 @@
 package com.srltas.runtogether.adapter.out.session;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 /**
@@ -10,7 +12,7 @@ public class SessionStorageImpl implements SessionStorage {
 
 	@Override
 	public UserSessionDTO getUserFromSessionId(String sessionId) {
-		return new UserSessionDTO(101L, "user_name");
+		return new UserSessionDTO("usr_" + UUID.randomUUID(), "user_name");
 	}
 
 	@Override

--- a/src/main/java/com/srltas/runtogether/adapter/out/session/UserSessionDTO.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/session/UserSessionDTO.java
@@ -1,7 +1,7 @@
 package com.srltas.runtogether.adapter.out.session;
 
 public record UserSessionDTO(
-	Long userId,
+	String userId,
 	String userName
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
+++ b/src/main/java/com/srltas/runtogether/application/NeighborhoodVerificationService.java
@@ -29,7 +29,7 @@ public class NeighborhoodVerificationService implements NeighborhoodVerification
 	private final UserRepository userRepository;
 
 	@Override
-	public NeighborhoodVerificationResult verifyAndRegisterNeighborhood(long userId,
+	public NeighborhoodVerificationResult verifyAndRegisterNeighborhood(String userId,
 		NeighborhoodVerificationCommand command) {
 		Neighborhood neighborhood = neighborhoodRepository.findById(command.neighborhoodId())
 			.orElseThrow(NeighborhoodNotFoundException::new);

--- a/src/main/java/com/srltas/runtogether/application/port/in/AddUserNeighborhoodCommand.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/AddUserNeighborhoodCommand.java
@@ -1,7 +1,7 @@
 package com.srltas.runtogether.application.port.in;
 
 public record AddUserNeighborhoodCommand(
-	long userId,
-	int neighborhoodId
+	String userId,
+	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationCommand.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationCommand.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 public record NeighborhoodVerificationCommand(
 	double latitude,
 	double longitude,
-	int neighborhoodId
+	String neighborhoodId
 ) {
 }

--- a/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationUseCase.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/NeighborhoodVerificationUseCase.java
@@ -1,6 +1,6 @@
 package com.srltas.runtogether.application.port.in;
 
 public interface NeighborhoodVerificationUseCase {
-	NeighborhoodVerificationResult verifyAndRegisterNeighborhood(long userId,
+	NeighborhoodVerificationResult verifyAndRegisterNeighborhood(String userId,
 		NeighborhoodVerificationCommand neighborhoodVerificationCommand);
 }

--- a/src/main/java/com/srltas/runtogether/application/port/out/VerifyUserNeighborhoodCommand.java
+++ b/src/main/java/com/srltas/runtogether/application/port/out/VerifyUserNeighborhoodCommand.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 
 @Builder
 public record VerifyUserNeighborhoodCommand(
-	long userId,
-	int neighborhoodId,
+	String userId,
+	String neighborhoodId,
 	boolean verified,
 	LocalDateTime verifiedAt
 ) {

--- a/src/main/java/com/srltas/runtogether/domain/model/neighborhood/Neighborhood.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/neighborhood/Neighborhood.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Neighborhood {
 
-	private final int id;
+	private final String id;
 	private final String name;
 	private final Location location;
 	private final double boundaryRadius;

--- a/src/main/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodRepository.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NeighborhoodRepository {
-	Optional<Neighborhood> findById(int neighborhoodId);
+	Optional<Neighborhood> findById(String neighborhoodId);
 }

--- a/src/main/java/com/srltas/runtogether/domain/model/user/User.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/user/User.java
@@ -15,9 +15,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class User {
 
-	private final Long id;
+	private final String id;
 	private final String name;
-	private final Map<Integer, UserNeighborhood> userNeighborhoods = new HashMap<>();
+	private final Map<String, UserNeighborhood> userNeighborhoods = new HashMap<>();
 
 	public void addNeighborhood(Neighborhood neighborhood) {
 		if (userNeighborhoods.size() >= 2) {
@@ -31,7 +31,7 @@ public class User {
 		userNeighborhoods.put(neighborhood.getId(), new UserNeighborhood(neighborhood));
 	}
 
-	public UserNeighborhood verifiedNeighborhood(int neighborhoodId) {
+	public UserNeighborhood verifiedNeighborhood(String neighborhoodId) {
 		UserNeighborhood userNeighborhood = userNeighborhoods.get(neighborhoodId);
 
 		if (isNull(userNeighborhood)) {

--- a/src/main/java/com/srltas/runtogether/domain/model/user/UserRepository.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/user/UserRepository.java
@@ -3,8 +3,8 @@ package com.srltas.runtogether.domain.model.user;
 import java.util.Optional;
 
 public interface UserRepository {
-	Optional<User> findById(long id);
+	Optional<User> findById(String id);
 	void save(User user);
-	void addUserNeighborhood(long userId, int neighborhoodId);
-	void updateVerifiedUserNeighborhood(long userId, UserNeighborhood neighborhood);
+	void addUserNeighborhood(String userId, String neighborhoodId);
+	void updateVerifiedUserNeighborhood(String userId, UserNeighborhood neighborhood);
 }

--- a/src/test/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/NeighborhoodVerificationControllerTest.java
@@ -1,11 +1,13 @@
 package com.srltas.runtogether.adapter.in;
 
 import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.*;
 
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -62,11 +64,11 @@ class NeighborhoodVerificationControllerTest {
 
 	static Stream<Arguments> provideRequestsForSuccess() {
 		return Stream.of(
-			Arguments.of(new NeighborhoodVerificationRequest(37.579617, 126.977041, 1),
-				new UserSessionDTO(123L, "user1")),
-			Arguments.of(new NeighborhoodVerificationRequest(37.556201, 126.972286, 2),
-				new UserSessionDTO(456L, "user2")),
-			Arguments.of(new NeighborhoodVerificationRequest(37.497911, 127.027618, 3),
-				new UserSessionDTO(789L, "user3")));
+			Arguments.of(new NeighborhoodVerificationRequest(37.579617, 126.977041, generateNeighborhoodId()),
+				new UserSessionDTO(generateUserId(), "user1")),
+			Arguments.of(new NeighborhoodVerificationRequest(37.556201, 126.972286, generateNeighborhoodId()),
+				new UserSessionDTO(generateUserId() + UUID.randomUUID(), "user2")),
+			Arguments.of(new NeighborhoodVerificationRequest(37.497911, 127.027618, generateNeighborhoodId()),
+				new UserSessionDTO(generateUserId(), "user3")));
 	}
 }

--- a/src/test/java/com/srltas/runtogether/adapter/in/UserNeighborhoodControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/UserNeighborhoodControllerTest.java
@@ -1,6 +1,7 @@
 package com.srltas.runtogether.adapter.in;
 
 import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.*;
@@ -36,13 +37,13 @@ class UserNeighborhoodControllerTest {
 	@Test
 	@DisplayName("내 동네 등록 성공")
 	void testAddUserNeighborhoodSuccess() {
-		AddUserNeighborhoodRequest request = new AddUserNeighborhoodRequest(100);
-		UserSessionDTO userSessionDTO = new UserSessionDTO(1L, "user1");
+		AddUserNeighborhoodRequest request = new AddUserNeighborhoodRequest(generateNeighborhoodId());
+		UserSessionDTO userSessionDTO = new UserSessionDTO(generateUserId(), "user1");
 		given(session.getAttribute(USER_SESSION)).willReturn(userSessionDTO);
 
 		ResponseEntity<Void> response = userNeighborhoodController.addUserNeighborhood(request, session);
 
-		assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
+		assertThat(response.getStatusCode(), is(HttpStatus.OK));
 		verify(addUserNeighborhood).addNeighborhood(
 			new AddUserNeighborhoodCommand(userSessionDTO.userId(), request.neighborhoodId()));
 	}

--- a/src/test/java/com/srltas/runtogether/adapter/in/web/filter/AuthenticationFilterTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/web/filter/AuthenticationFilterTest.java
@@ -2,6 +2,7 @@ package com.srltas.runtogether.adapter.in.web.filter;
 
 import static com.srltas.runtogether.adapter.in.web.common.AuthConstants.*;
 import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
 import static jakarta.servlet.http.HttpServletResponse.*;
 import static org.mockito.Mockito.*;
 
@@ -51,7 +52,7 @@ class AuthenticationFilterTest {
 	@DisplayName("유효한 토큰을 통해 사용자가 인증되는지 확인")
 	void testValidToken_UserAuthenticated() throws ServletException, IOException {
 		// given
-		UserSessionDTO userSessionDTO = new UserSessionDTO(123L, "testUserName");
+		UserSessionDTO userSessionDTO = new UserSessionDTO(generateUserId(), "testUserName");
 		when(request.getHeader(AUTHORIZATION)).thenReturn(BEARER_TOKEN_PREFIX + VALID_TOKEN);
 		when(sessionStorage.getUserFromSessionId(VALID_TOKEN)).thenReturn(userSessionDTO);
 		when(request.getSession(true)).thenReturn(session);

--- a/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisUserRepositoryTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisUserRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.srltas.runtogether.adapter.out.persistence.mybatis;
 
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
 import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -27,12 +28,11 @@ class MybatisUserRepositoryTest {
 	@Test
 	@DisplayName("동네 인증 정보 업데이트 SQL 실행 위임을 검증")
 	void shouldCallMapperToUserRepository() {
-		long userId = 1L;
-		Neighborhood neighborhood = new Neighborhood(1, "Test Neighborhood",
+		Neighborhood neighborhood = new Neighborhood(generateNeighborhoodId(), "Test Neighborhood",
 			new Location(37.505858, 127.058319), 5.0);
 		UserNeighborhood userNeighborhood = new UserNeighborhood(neighborhood);
 
-		mybatisUserRepository.updateVerifiedUserNeighborhood(userId, userNeighborhood);
+		mybatisUserRepository.updateVerifiedUserNeighborhood(generateUserId(), userNeighborhood);
 
 		verify(mybatisUserMapper).updateVerifiedUserNeighborhood(any(VerifiedUserNeighborhoodDAO.class));
 	}
@@ -40,11 +40,7 @@ class MybatisUserRepositoryTest {
 	@Test
 	@DisplayName("내 동네 등록 SQL 실행 위임 검증")
 	void shouldCallMapperToAddUserNeighborhood() {
-		long userId = 1L;
-		int neighborhoodId = 2;
-
-		mybatisUserRepository.addUserNeighborhood(userId, neighborhoodId);
-
+		mybatisUserRepository.addUserNeighborhood(generateUserId(), generateNeighborhoodId());
 		verify(mybatisUserMapper).addUserNeighborhood(any(AddUserNeighborhoodDAO.class));
 	}
 }

--- a/src/test/java/com/srltas/runtogether/application/UserNeighborhoodServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/application/UserNeighborhoodServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,8 +36,8 @@ class UserNeighborhoodServiceTest {
 	@DisplayName("사용자가 동네를 성공적으로 등록하는 경우")
 	void testAddNeighborhoodSuccess() {
 		// given
-		long userId = 1L;
-		int neighborhoodId = 101;
+		String userId = "usr_" + UUID.randomUUID();
+		String neighborhoodId = "nhd" + UUID.randomUUID();
 
 		User user = new User(userId, "testUser");
 		Neighborhood neighborhood = new Neighborhood(neighborhoodId, "Gangnam",

--- a/src/test/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/neighborhood/NeighborhoodTest.java
@@ -1,6 +1,7 @@
 package com.srltas.runtogether.domain.model.neighborhood;
 
 import static com.srltas.runtogether.domain.model.neighborhood.LocationUtils.*;
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.*;
@@ -23,7 +24,7 @@ class NeighborhoodTest {
 	public void setUp() {
 		currentLocation = new Location(37.505858, 127.058319);
 		neighborhoodLocation = new Location(37.517347, 127.047382);
-		neighborhood = new Neighborhood(1, "Gangnam", neighborhoodLocation, 7.0);
+		neighborhood = new Neighborhood(generateNeighborhoodId(), "Gangnam", neighborhoodLocation, 7.0);
 	}
 
 	@Test

--- a/src/test/java/com/srltas/runtogether/domain/model/user/UserTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/user/UserTest.java
@@ -1,5 +1,6 @@
 package com.srltas.runtogether.domain.model.user;
 
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,31 +12,26 @@ import com.srltas.runtogether.domain.model.neighborhood.Neighborhood;
 
 class UserTest {
 
-	private final User user = new User(1L, "TestUser");
-	private final Neighborhood neighborhood1 = new Neighborhood(101, "Gangnam",
+	private final String neighborhoodId1 = generateNeighborhoodId();
+	private final User user = new User(generateUserId(), "TestUser");
+	private final Neighborhood neighborhood1 = new Neighborhood(neighborhoodId1, "Gangnam",
 		new Location(37.4979, 127.0276), 5.0);
 
 	@Test
 	@DisplayName("성공적으로 동네를 등록한다")
 	void testAddNeighborhoodSuccess() {
-		// when
 		user.addNeighborhood(neighborhood1);
-
-		// then
 		assertThat(user.getUserNeighborhoods().size()).isEqualTo(1);
 	}
 
 	@Test
 	@DisplayName("동네 인증이 정상적으로 동작한다")
 	void testVerifyNeighborhoodSuccess() {
-		// given
 		user.addNeighborhood(neighborhood1);
 
-		// when
-		user.verifiedNeighborhood(101);
+		user.verifiedNeighborhood(neighborhoodId1);
 
-		// then
-		UserNeighborhood userNeighborhood = user.getUserNeighborhoods().get(101);
+		UserNeighborhood userNeighborhood = user.getUserNeighborhoods().get(neighborhoodId1);
 		assertThat(userNeighborhood.isVerified()).isTrue();
 		assertThat(userNeighborhood.getVerifiedAt()).isNotNull();
 	}
@@ -43,17 +39,15 @@ class UserTest {
 	@Test
 	@DisplayName("최대 2개의 동네만 등록할 수 있다")
 	void testAddNeighborhoodExceedsLimit() {
-		// given
-		Neighborhood neighborhood2 = new Neighborhood(102, "Seocho",
+		Neighborhood neighborhood2 = new Neighborhood(generateNeighborhoodId(), "Seocho",
 			new Location(37.4839, 127.0323), 5.0);
-		Neighborhood neighborhood3 = new Neighborhood(103, "Mapo",
+		Neighborhood neighborhood3 = new Neighborhood(generateNeighborhoodId(), "Mapo",
 			new Location(37.5547, 126.9707), 5.0);
 
-		// when
+
 		user.addNeighborhood(neighborhood1);
 		user.addNeighborhood(neighborhood2);
 
-		// then
 		assertThatThrownBy(() -> user.addNeighborhood(neighborhood3))
 			.isInstanceOf(CommonException.class)
 			.hasMessageContaining("최대 2개의 동네만 등록할 수 있습니다.");
@@ -62,10 +56,8 @@ class UserTest {
 	@Test
 	@DisplayName("동일한 동네를 중복 등록할 수 없다")
 	void testAddNeighborhoodDuplicate() {
-		// given
 		user.addNeighborhood(neighborhood1);
 
-		// when & then
 		assertThatThrownBy(() -> user.addNeighborhood(neighborhood1))
 			.isInstanceOf(CommonException.class)
 			.hasMessageContaining("이미 등록된 동네입니다.");
@@ -74,8 +66,7 @@ class UserTest {
 	@Test
 	@DisplayName("동네가 등록되지 않은 경우 인증 시 에러가 발생한다")
 	void testVerifyNeighborhoodNotRegistered() {
-		// when & then
-		assertThatThrownBy(() -> user.verifiedNeighborhood(101))
+		assertThatThrownBy(() -> user.verifiedNeighborhood(generateNeighborhoodId()))
 			.isInstanceOf(CommonException.class)
 			.hasMessageContaining("해당 동네가 등록되지 않았습니다.");
 	}

--- a/src/test/java/com/srltas/runtogether/testutil/TestIdGenerator.java
+++ b/src/test/java/com/srltas/runtogether/testutil/TestIdGenerator.java
@@ -1,0 +1,17 @@
+package com.srltas.runtogether.testutil;
+
+import java.util.UUID;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TestIdGenerator {
+
+	public String generateUserId() {
+		return "test_usr_" + UUID.randomUUID();
+	}
+
+	public String generateNeighborhoodId() {
+		return "test_neighborhood_" + UUID.randomUUID();
+	}
+}


### PR DESCRIPTION
## 📌 Summary
User, Neighborhood 객체 ID 데이터 타입을 String으로 변경합니다.

## 📝 Description
ID 생성 시 중요한 요소인 고유성, 식별 가능성, 보안성을 최대한 반영하기 위해 데이터 타입을 String으로 변경합니다.

UUID를 사용하여 고유성과 보안성을 강화하였고, 객체 종류에 따라 `usr_`, `nhd_`와 같은 접두사를 붙여 식별 가능성을 높였습니다. 이를 통해 각 객체의 ID가 고유하면서 명확하게 구분될 수 있도록 개선하였습니다.

테스트 코드에서 객체 ID를 생성하는 유틸 클래스를 추가 했습니다.

## 📚 References
[좋은 객체ID(Object ID) 만들기](https://docs.tosspayments.com/blog/making-object-ids)
[Designing APIs for humans: Object IDs](https://dev.to/stripe/designing-apis-for-humans-object-ids-3o5a)

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
