### PR TITLE
[#92] 러닝 그룹 생성 도메인 로직 및 서비스 계층 구현

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/GroupConverter.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/GroupConverter.java
@@ -13,8 +13,8 @@ public class GroupConverter {
 			.groupId(group.getId())
 			.groupName(group.getName())
 			.description(group.getDescription())
-			.neighborhoodId(group.getNeighborhood().getId())
-			.createByUserId(group.getCreateByUser().getId())
+			.neighborhoodId(group.getNeighborhoodId())
+			.createByUserId(group.getCreateByUserId())
 			.createAt(group.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/srltas/runtogether/application/GroupService.java
+++ b/src/main/java/com/srltas/runtogether/application/GroupService.java
@@ -1,0 +1,30 @@
+package com.srltas.runtogether.application;
+
+import org.springframework.stereotype.Service;
+
+import com.srltas.runtogether.application.port.in.AddGroup;
+import com.srltas.runtogether.application.port.in.AddGroupCommand;
+import com.srltas.runtogether.domain.model.group.Group;
+import com.srltas.runtogether.domain.model.group.GroupCreationService;
+import com.srltas.runtogether.domain.model.group.GroupRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService implements AddGroup {
+
+	private final GroupCreationService groupCreationService;
+	private final GroupRepository groupRepository;
+
+	@Override
+	public void create(AddGroupCommand command) {
+		Group group = groupCreationService.create(
+			command.name(),
+			command.description(),
+			command.neighborhoodId(),
+			command.createByUserId());
+
+		groupRepository.save(group);
+	}
+}

--- a/src/main/java/com/srltas/runtogether/application/port/in/AddGroup.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/AddGroup.java
@@ -1,0 +1,5 @@
+package com.srltas.runtogether.application.port.in;
+
+public interface AddGroup {
+	void create(AddGroupCommand command);
+}

--- a/src/main/java/com/srltas/runtogether/application/port/in/AddGroupCommand.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/AddGroupCommand.java
@@ -1,0 +1,9 @@
+package com.srltas.runtogether.application.port.in;
+
+public record AddGroupCommand(
+	String name,
+	String description,
+	String neighborhoodId,
+	String createByUserId
+) {
+}

--- a/src/main/java/com/srltas/runtogether/domain/model/group/Group.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/group/Group.java
@@ -1,10 +1,7 @@
 package com.srltas.runtogether.domain.model.group;
 
 import java.time.LocalDateTime;
-import java.util.Map;
-
-import com.srltas.runtogether.domain.model.neighborhood.Neighborhood;
-import com.srltas.runtogether.domain.model.user.User;
+import java.util.Set;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -18,9 +15,9 @@ public class Group {
 	private final String id;
 	private final String name;
 	private final String description;
-	private final Neighborhood neighborhood;
-	private final User createByUser;
+	private final String neighborhoodId;
+	private final String createByUserId;
 	private final LocalDateTime createdAt;
 
-	private final Map<String, User> groupMembers;
+	private final Set<String> groupMemberIds;
 }

--- a/src/main/java/com/srltas/runtogether/domain/model/group/GroupCreationService.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/group/GroupCreationService.java
@@ -1,0 +1,35 @@
+package com.srltas.runtogether.domain.model.group;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.srltas.runtogether.application.exception.UserNotFoundException;
+import com.srltas.runtogether.domain.model.neighborhood.exception.NeighborhoodNotRegisteredException;
+import com.srltas.runtogether.domain.model.user.User;
+import com.srltas.runtogether.domain.model.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GroupCreationService {
+
+	private final UserRepository userRepository;
+
+	public Group create(String name, String description, String neighborhoodId, String createByUserId) {
+		User user = userRepository.findById(createByUserId).orElseThrow(UserNotFoundException::new);
+		if (!user.isVerifiedNeighborhood(neighborhoodId)) {
+			throw new NeighborhoodNotRegisteredException();
+		}
+
+		String groupId = "rg_" + UUID.randomUUID();
+		LocalDateTime createdAt = LocalDateTime.now();
+		Set<String> groupMemberIds = Collections.emptySet();
+
+		return new Group(groupId, name, description, neighborhoodId, createByUserId, createdAt, groupMemberIds);
+	}
+}

--- a/src/main/java/com/srltas/runtogether/domain/model/user/User.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/user/User.java
@@ -48,4 +48,8 @@ public class User {
 		userNeighborhood.verifyNeighborhood();
 		return userNeighborhood;
 	}
+
+	public boolean isVerifiedNeighborhood(String neighborhoodId) {
+		return userNeighborhoods.containsKey(neighborhoodId);
+	}
 }

--- a/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepositoryTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepositoryTest.java
@@ -12,8 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.AddGroupDTO;
 import com.srltas.runtogether.domain.model.group.Group;
-import com.srltas.runtogether.domain.model.neighborhood.Neighborhood;
-import com.srltas.runtogether.domain.model.user.User;
 
 @ExtendWith(MockitoExtension.class)
 class MybatisGroupRepositoryTest {
@@ -28,14 +26,9 @@ class MybatisGroupRepositoryTest {
 	@DisplayName("러닝 그룹 조회 SQL 실행 위임을 검증")
 	void shouldCallMapperToGroupRepository() {
 		Group mockGroup = mock(Group.class);
-		Neighborhood mockNeighborhood = mock(Neighborhood.class);
-		User mockUser = mock(User.class);
 
-		when(mockGroup.getNeighborhood()).thenReturn(mockNeighborhood);
-		when(mockGroup.getCreateByUser()).thenReturn(mockUser);
-
-		when(mockNeighborhood.getId()).thenReturn(generateNeighborhoodId());
-		when(mockUser.getId()).thenReturn(generateUserId());
+		when(mockGroup.getNeighborhoodId()).thenReturn(generateNeighborhoodId());
+		when(mockGroup.getCreateByUserId()).thenReturn(generateUserId());
 
 		groupRepository.save(mockGroup);
 		verify(groupMapper).save(any(AddGroupDTO.class));

--- a/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/GroupConverterTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/GroupConverterTest.java
@@ -35,8 +35,8 @@ class GroupConverterTest {
 			.id(groupId)
 			.name("Test Group")
 			.description("Test Description")
-			.neighborhood(mockNeighborhood)
-			.createByUser(mockUser)
+			.neighborhoodId(neighborhoodId)
+			.createByUserId(userId)
 			.createdAt(createTime)
 			.build();
 

--- a/src/test/java/com/srltas/runtogether/application/GroupServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/application/GroupServiceTest.java
@@ -1,0 +1,89 @@
+package com.srltas.runtogether.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.srltas.runtogether.application.port.in.AddGroupCommand;
+import com.srltas.runtogether.domain.model.group.Group;
+import com.srltas.runtogether.domain.model.group.GroupCreationService;
+import com.srltas.runtogether.domain.model.group.GroupRepository;
+import com.srltas.runtogether.domain.model.neighborhood.exception.NeighborhoodNotRegisteredException;
+import com.srltas.runtogether.testutil.TestIdGenerator;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+	@Mock
+	private GroupCreationService groupCreationService;
+
+	@Mock
+	private GroupRepository groupRepository;
+
+	@InjectMocks
+	private GroupService groupService;
+
+	private AddGroupCommand command = new AddGroupCommand(
+		"Test Group",
+		"Description",
+		"nh_123",
+		"user_123");
+
+	@Test
+	@DisplayName("정상적으로 Group을 생성하고 저장")
+	void create_whenValidCommand_thenSavesGroup() {
+		// given
+		Group createGroup = new Group(
+			TestIdGenerator.generateGroupId(),
+			command.name(),
+			command.description(),
+			command.neighborhoodId(),
+			command.createByUserId(),
+			LocalDateTime.now(),
+			Collections.emptySet()
+		);
+
+		when(groupCreationService.create(
+			command.name(),
+			command.description(),
+			command.neighborhoodId(),
+			command.createByUserId()
+		)).thenReturn(createGroup);
+
+		//when
+		groupService.create(command);
+
+		// then
+		verify(groupCreationService).create(
+			command.name(),
+			command.description(),
+			command.neighborhoodId(),
+			command.createByUserId()
+		);
+
+		verify(groupRepository).save(createGroup);
+	}
+
+	@Test
+	@DisplayName("그룹 생성 과정에서 예외가 발생하면, repository.save는 호출되지 않음")
+	void create_whenGroupCreationThrowsException_thenSaveNotCalled() {
+		// given
+		when(groupCreationService.create(anyString(), anyString(), anyString(), anyString()))
+			.thenThrow(new NeighborhoodNotRegisteredException());
+
+		// when & then
+		assertThatThrownBy(() -> groupService.create(command))
+			.isInstanceOf(NeighborhoodNotRegisteredException.class);
+
+		verifyNoMoreInteractions(groupRepository);
+	}
+}

--- a/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
@@ -26,19 +26,19 @@ class GroupCreationServiceTest {
 	@InjectMocks
 	private GroupCreationService groupCreationService;
 
-	private final String USER_ID = generateUserId();
-	private final String VALID_NEIGHBORHOOD_ID = generateNeighborhoodId();
-	private final String INVALID_NEIGHBORHOOD_ID = generateNeighborhoodId();
+	private final String userId = generateUserId();
+	private final String validNeighborhoodId = generateNeighborhoodId();
+	private final String invalidNeighborhoodId = generateNeighborhoodId();
 
 	private User mockUser = mock(User.class);
 
 	@Test
 	@DisplayName("그룹 생성 성공")
 	void testCreateGroupSuccess() {
-		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(mockUser));
-		when(mockUser.isVerifiedNeighborhood(VALID_NEIGHBORHOOD_ID)).thenReturn(true);
+		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(mockUser.isVerifiedNeighborhood(validNeighborhoodId)).thenReturn(true);
 
-		Group group = groupCreationService.create("Test Group", "Test Desc", VALID_NEIGHBORHOOD_ID, USER_ID);
+		Group group = groupCreationService.create("Test Group", "Test Desc", validNeighborhoodId, userId);
 
 		assertThat(group).isNotNull();
 	}
@@ -46,11 +46,11 @@ class GroupCreationServiceTest {
 	@Test
 	@DisplayName("그룹 생성 실패(내 동네로 등록하지 않음)")
 	void testCreateGroupFailure() {
-		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(mockUser));
-		when(mockUser.isVerifiedNeighborhood(INVALID_NEIGHBORHOOD_ID)).thenReturn(false);
+		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(mockUser.isVerifiedNeighborhood(invalidNeighborhoodId)).thenReturn(false);
 
 		assertThatThrownBy(() -> {
-			groupCreationService.create("Test Group", "Test Desc", INVALID_NEIGHBORHOOD_ID, USER_ID);
+			groupCreationService.create("Test Group", "Test Desc", invalidNeighborhoodId, userId);
 		}).isInstanceOf(NeighborhoodNotRegisteredException.class);
 	}
 }

--- a/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
@@ -50,9 +50,9 @@ class GroupCreationServiceTest {
 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
 		when(mockUser.isVerifiedNeighborhood(invalidNeighborhoodId)).thenReturn(false);
 
-		assertThatThrownBy(() -> {
-			groupCreationService.create("Test Group", "Test Desc", invalidNeighborhoodId, userId);
-		}).isInstanceOf(NeighborhoodNotRegisteredException.class);
+		assertThatThrownBy(() ->
+			groupCreationService.create("Test Group", "Test Desc", invalidNeighborhoodId, userId))
+			.isInstanceOf(NeighborhoodNotRegisteredException.class);
 	}
 
 	@Test

--- a/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
@@ -1,0 +1,56 @@
+package com.srltas.runtogether.domain.model.group;
+
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.srltas.runtogether.domain.model.neighborhood.exception.NeighborhoodNotRegisteredException;
+import com.srltas.runtogether.domain.model.user.User;
+import com.srltas.runtogether.domain.model.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GroupCreationServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private GroupCreationService groupCreationService;
+
+	private final String USER_ID = generateUserId();
+	private final String VALID_NEIGHBORHOOD_ID = generateNeighborhoodId();
+	private final String INVALID_NEIGHBORHOOD_ID = generateNeighborhoodId();
+
+	private User mockUser = mock(User.class);
+
+	@Test
+	@DisplayName("그룹 생성 성공")
+	void testCreateGroupSuccess() {
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(mockUser));
+		when(mockUser.isVerifiedNeighborhood(VALID_NEIGHBORHOOD_ID)).thenReturn(true);
+
+		Group group = groupCreationService.create("Test Group", "Test Desc", VALID_NEIGHBORHOOD_ID, USER_ID);
+
+		assertThat(group).isNotNull();
+	}
+
+	@Test
+	@DisplayName("그룹 생성 실패(내 동네로 등록하지 않음)")
+	void testCreateGroupFailure() {
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(mockUser));
+		when(mockUser.isVerifiedNeighborhood(INVALID_NEIGHBORHOOD_ID)).thenReturn(false);
+
+		assertThatThrownBy(() -> {
+			groupCreationService.create("Test Group", "Test Desc", INVALID_NEIGHBORHOOD_ID, USER_ID);
+		}).isInstanceOf(NeighborhoodNotRegisteredException.class);
+	}
+}

--- a/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/domain/model/group/GroupCreationServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.srltas.runtogether.application.exception.UserNotFoundException;
 import com.srltas.runtogether.domain.model.neighborhood.exception.NeighborhoodNotRegisteredException;
 import com.srltas.runtogether.domain.model.user.User;
 import com.srltas.runtogether.domain.model.user.UserRepository;
@@ -52,5 +53,15 @@ class GroupCreationServiceTest {
 		assertThatThrownBy(() -> {
 			groupCreationService.create("Test Group", "Test Desc", invalidNeighborhoodId, userId);
 		}).isInstanceOf(NeighborhoodNotRegisteredException.class);
+	}
+
+	@Test
+	@DisplayName("그룹 생성 실패(사용자가 없는 경우)")
+	void testCreateGroupFailure_no_users() {
+		when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() ->
+			groupCreationService.create("Test Group", "Test Desc", validNeighborhoodId, userId))
+			.isInstanceOf(UserNotFoundException.class);
 	}
 }


### PR DESCRIPTION
## 📌 Summary
그룹 생성 기능과 관련된 서비스와 도메인 서비스를 구현했습니다.

## 📝 Description
**도메인 서비스(GroupCreationService)**
- "내 동네로 인증된 동네만 그룹을 생성할 수 있다" 는 그룹 생성과 내 동네 검증을 결합한 도메인 규칙입니다.
- Group 도메인 모델에서 이 도메인 규칙을 수행하기 위해서는 `UserRepository`, `User`와 같은 외부 애그리거트를 알아야 하고 이는 결합도 상승으로 이어집니다.
- 따라서, Group과 User의 다른 애그리거트 간의 조합 로직은 도메인 서비스로 풀어서 만들기로 결정했습니다.

**Group 도메인 ID 참조로 변경**
- 하나의 Neighborhood에는 여러 Group이 생길 수 있고, 특정 Neighborhood가 변경되거나 삭제된다고 해서 관련된 모든 Group이 영향을 받지 않습니다.
- User가 탈퇴해도 그룹 자체는 계속 유지될 수 있고, 그룹이 삭제된다고 해서 User가 사라지는 것이 아닙니다.
- 위 경우를 생각했을 때 Group과 독립적인 애그리거트로 취급해야 합니다.
- DDD에서는 애그리거트 간에 식별자(ID)를 통해 참조하는 것을 권장하기에 Group 도메인에 있는 Neighborhood와 User를 ID로만 참조하는 방식으로 수정했습니다. 

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
