### PR TITLE
[#94] 러닝 그룹 생성 Controller 구현

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/in/GroupController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/GroupController.java
@@ -1,0 +1,46 @@
+package com.srltas.runtogether.adapter.in;
+
+import static com.srltas.runtogether.adapter.in.web.common.SessionUtils.*;
+import static com.srltas.runtogether.adapter.in.web.common.UrlConstants.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.srltas.runtogether.adapter.in.web.dto.AddGroupRequest;
+import com.srltas.runtogether.adapter.out.session.UserSession;
+import com.srltas.runtogether.application.port.in.AddGroup;
+import com.srltas.runtogether.application.port.in.AddGroupCommand;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping(GROUP)
+@RestController
+@RequiredArgsConstructor
+public class GroupController {
+
+	private final AddGroup addGroup;
+
+	@Operation(
+		summary = "그룹 생성",
+		description = "내 동네에 그룹을 생성합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "그룹 생성 성공")
+	@PostMapping
+	public ResponseEntity<Void> create(
+		@RequestBody @Valid AddGroupRequest request, HttpSession session) {
+		UserSession userSession = getUserSession(session);
+		addGroup.create(new AddGroupCommand(
+			request.groupName(),
+			request.groupDescription(),
+			request.neighborhoodId(),
+			userSession.userId()));
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/common/UrlConstants.java
@@ -11,8 +11,9 @@ public class UrlConstants {
 	public static final String USER_NEIGHBORHOOD_PATTERN = "/users/neighborhoods/*";
 	public static final String NEIGHBORHOOD_VERIFICATION = "/users/neighborhoods/verification";
 	public static final String USER_NEIGHBORHOOD = "/users/neighborhoods";
+	public static final String GROUP = "/groups";
 
 	public List<String> getAuthRequiredUrls() {
-		return Arrays.asList(NEIGHBORHOOD_VERIFICATION, USER_NEIGHBORHOOD, USER_NEIGHBORHOOD_PATTERN);
+		return Arrays.asList(NEIGHBORHOOD_VERIFICATION, USER_NEIGHBORHOOD, USER_NEIGHBORHOOD_PATTERN, GROUP);
 	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddGroupRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/AddGroupRequest.java
@@ -1,0 +1,18 @@
+package com.srltas.runtogether.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AddGroupRequest(
+
+	@NotNull(message = "동네 ID는 필수입니다.")
+	String neighborhoodId,
+
+	@NotNull(message = "그룹 이름은 필수입니다.")
+	@Size(min = 2, max = 255, message = "그룹 이름은 2자 이상 255자 이하로 입력해야 합니다.")
+	String groupName,
+
+	@Size(max = 2000, message = "그룹 설명은 최대 2000자까지 입력할 수 있습니다.")
+	String groupDescription
+) {
+}

--- a/src/test/java/com/srltas/runtogether/adapter/in/GroupControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/GroupControllerTest.java
@@ -35,15 +35,13 @@ class GroupControllerTest {
 	private GroupController groupController;
 
 	@Test
-	@DisplayName("그룹 등록 성공")
+	@DisplayName("그룹 생성 성공")
 	void testAddGroupSuccess() {
 		String userId = generateUserId();
 		String neighborhoodId = generateNeighborhoodId();
 
 		AddGroupRequest request = new AddGroupRequest(
-			neighborhoodId,
-			"Test Group",
-			"Test Group Description");
+			neighborhoodId, "Test Group", "Test Group Description");
 		UserSession userSession = new UserSession(userId);
 		given(session.getAttribute(USER_SESSION)).willReturn(userSession);
 
@@ -51,10 +49,6 @@ class GroupControllerTest {
 
 		assertThat(response.getStatusCode(), is(HttpStatus.OK));
 		verify(addGroup).create(
-			new AddGroupCommand(
-				"Test Group",
-				"Test Group Description",
-				neighborhoodId,
-				userId));
+			new AddGroupCommand("Test Group", "Test Group Description", neighborhoodId, userId));
 	}
 }

--- a/src/test/java/com/srltas/runtogether/adapter/in/GroupControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/GroupControllerTest.java
@@ -1,0 +1,60 @@
+package com.srltas.runtogether.adapter.in;
+
+import static com.srltas.runtogether.adapter.in.web.common.SessionAttribute.*;
+import static com.srltas.runtogether.testutil.TestIdGenerator.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.srltas.runtogether.adapter.in.web.dto.AddGroupRequest;
+import com.srltas.runtogether.adapter.out.session.UserSession;
+import com.srltas.runtogether.application.port.in.AddGroup;
+import com.srltas.runtogether.application.port.in.AddGroupCommand;
+
+import jakarta.servlet.http.HttpSession;
+
+@ExtendWith(MockitoExtension.class)
+class GroupControllerTest {
+
+	@Mock
+	private AddGroup addGroup;
+
+	@Mock
+	HttpSession session;
+
+	@InjectMocks
+	private GroupController groupController;
+
+	@Test
+	@DisplayName("그룹 등록 성공")
+	void testAddGroupSuccess() {
+		String userId = generateUserId();
+		String neighborhoodId = generateNeighborhoodId();
+
+		AddGroupRequest request = new AddGroupRequest(
+			neighborhoodId,
+			"Test Group",
+			"Test Group Description");
+		UserSession userSession = new UserSession(userId);
+		given(session.getAttribute(USER_SESSION)).willReturn(userSession);
+
+		ResponseEntity<Void> response = groupController.create(request, session);
+
+		assertThat(response.getStatusCode(), is(HttpStatus.OK));
+		verify(addGroup).create(
+			new AddGroupCommand(
+				"Test Group",
+				"Test Group Description",
+				neighborhoodId,
+				userId));
+	}
+}


### PR DESCRIPTION
## 📌 Summary
러닝 그룹 생성 기능에 대한 Controller를 구현합니다.

## 📝 Description
**API**
- 메서드: POST
- 콘텐츠 유형: application/json
- 엔드포인트: /groups
- 러닝 그룹 생성을 위해 `사용자ID`, `동네ID`, `그룹 이름`, `그룹 소개 글`들을 요청에 받습니다.

**제약 조건**
- 로그인한 사용자만 그룹을 생성할 수 있습니다.
- 내 동네로 인증된 동네에 대해서 그룹을 생성할 수 있습니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
