### PR TITLE
[#96] 러닝 그룹 삭제 Repository 구현

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupMapper.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupMapper.java
@@ -3,8 +3,11 @@ package com.srltas.runtogether.adapter.out.persistence.mybatis;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.AddGroupDTO;
+import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.DeleteGroupDTO;
 
 @Mapper
 public interface MybatisGroupMapper {
 	void save(AddGroupDTO dto);
+
+	void delete(DeleteGroupDTO dto);
 }

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepository.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepository.java
@@ -19,4 +19,9 @@ public class MybatisGroupRepository implements GroupRepository {
 	public void save(Group group) {
 		mapper.save(toAddGroupDTO(group));
 	}
+
+	@Override
+	public void delete(String groupId) {
+		mapper.delete(toDeleteGroupDTO(groupId));
+	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepositoryLogProxy.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepositoryLogProxy.java
@@ -22,4 +22,11 @@ public class MybatisGroupRepositoryLogProxy implements GroupRepository {
 		groupRepository.save(group);
 		RunTogetherMDC.putMessage("add_group_SQL_time", String.valueOf(System.currentTimeMillis() - startTime));
 	}
+
+	@Override
+	public void delete(String groupId) {
+		long startTime = System.currentTimeMillis();
+		groupRepository.delete(groupId);
+		RunTogetherMDC.putMessage("delete_group_SQL_time", String.valueOf(System.currentTimeMillis() - startTime));
+	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/GroupConverter.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/converter/GroupConverter.java
@@ -1,6 +1,7 @@
 package com.srltas.runtogether.adapter.out.persistence.mybatis.converter;
 
 import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.AddGroupDTO;
+import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.DeleteGroupDTO;
 import com.srltas.runtogether.domain.model.group.Group;
 
 import lombok.experimental.UtilityClass;
@@ -16,6 +17,12 @@ public class GroupConverter {
 			.neighborhoodId(group.getNeighborhoodId())
 			.createByUserId(group.getCreateByUserId())
 			.createAt(group.getCreatedAt())
+			.build();
+	}
+
+	public DeleteGroupDTO toDeleteGroupDTO(String groupId) {
+		return DeleteGroupDTO.builder()
+			.groupId(groupId)
 			.build();
 	}
 }

--- a/src/main/java/com/srltas/runtogether/domain/model/group/GroupRepository.java
+++ b/src/main/java/com/srltas/runtogether/domain/model/group/GroupRepository.java
@@ -2,4 +2,6 @@ package com.srltas.runtogether.domain.model.group;
 
 public interface GroupRepository {
 	void save(Group group);
+
+	void delete(String groupId);
 }

--- a/src/main/resources/mapper/GroupMapper.xml
+++ b/src/main/resources/mapper/GroupMapper.xml
@@ -8,4 +8,9 @@
         INSERT INTO running_groups (id, name, description, neighborhood_id, create_by_user_id, create_at)
         VALUES (#{groupId}, #{groupName}, #{description}, #{neighborhoodId}, #{createByUserId}, #{createAt})
     </insert>
+
+    <delete id="delete" parameterType="DeleteGroupDTO">
+        DELETE FROM running_groups
+        WHERE id = #{groupId}
+    </delete>
 </mapper>

--- a/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepositoryTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/out/persistence/mybatis/MybatisGroupRepositoryTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.AddGroupDTO;
+import com.srltas.runtogether.adapter.out.persistence.mybatis.dto.DeleteGroupDTO;
 import com.srltas.runtogether.domain.model.group.Group;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,7 +24,7 @@ class MybatisGroupRepositoryTest {
 	private MybatisGroupRepository groupRepository;
 
 	@Test
-	@DisplayName("러닝 그룹 조회 SQL 실행 위임을 검증")
+	@DisplayName("러닝 그룹 생성 SQL 실행 위임을 검증")
 	void shouldCallMapperToGroupRepository() {
 		Group mockGroup = mock(Group.class);
 
@@ -32,5 +33,12 @@ class MybatisGroupRepositoryTest {
 
 		groupRepository.save(mockGroup);
 		verify(groupMapper).save(any(AddGroupDTO.class));
+	}
+
+	@Test
+	@DisplayName("러닝 그룹 삭제 SQL 실행 위임을 검증")
+	void test() {
+		groupRepository.delete(generateGroupId());
+		verify(groupMapper).delete(any(DeleteGroupDTO.class));
 	}
 }


### PR DESCRIPTION
## 📌 Summary
러닝 그룹 삭제 기능의 Repository를 구현합니다.

## 📝 Description
- 도메인 Repository, MybatisGroupRepository에 삭제 기능 추가
- MybatisGroupRepositoryLogProxy 그룹 삭제에 대한 로그 기록 추가
- MybatisMapper 그룹 삭제 SQL 작성

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
