### PR TITLE
[#98] 러닝 그룹 삭제 Service 계층 구현

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/dto/DeleteGroupDTO.java
+++ b/src/main/java/com/srltas/runtogether/adapter/out/persistence/mybatis/dto/DeleteGroupDTO.java
@@ -1,0 +1,9 @@
+package com.srltas.runtogether.adapter.out.persistence.mybatis.dto;
+
+import lombok.Builder;
+
+@Builder
+public record DeleteGroupDTO(
+	String groupId
+) {
+}

--- a/src/main/java/com/srltas/runtogether/application/GroupService.java
+++ b/src/main/java/com/srltas/runtogether/application/GroupService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 import com.srltas.runtogether.application.port.in.AddGroup;
 import com.srltas.runtogether.application.port.in.AddGroupCommand;
+import com.srltas.runtogether.application.port.in.DeleteGroup;
+import com.srltas.runtogether.application.port.in.DeleteGroupCommand;
 import com.srltas.runtogether.domain.model.group.Group;
 import com.srltas.runtogether.domain.model.group.GroupCreationService;
 import com.srltas.runtogether.domain.model.group.GroupRepository;
@@ -12,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class GroupService implements AddGroup {
+public class GroupService implements AddGroup, DeleteGroup {
 
 	private final GroupCreationService groupCreationService;
 	private final GroupRepository groupRepository;
@@ -26,5 +28,10 @@ public class GroupService implements AddGroup {
 			command.createByUserId());
 
 		groupRepository.save(group);
+	}
+
+	@Override
+	public void delete(DeleteGroupCommand command) {
+		groupRepository.delete(command.groupId());
 	}
 }

--- a/src/main/java/com/srltas/runtogether/application/port/in/DeleteGroup.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/DeleteGroup.java
@@ -1,0 +1,5 @@
+package com.srltas.runtogether.application.port.in;
+
+public interface DeleteGroup {
+	void delete(DeleteGroupCommand command);
+}

--- a/src/main/java/com/srltas/runtogether/application/port/in/DeleteGroupCommand.java
+++ b/src/main/java/com/srltas/runtogether/application/port/in/DeleteGroupCommand.java
@@ -1,0 +1,6 @@
+package com.srltas.runtogether.application.port.in;
+
+public record DeleteGroupCommand(
+	String groupId
+) {
+}

--- a/src/test/java/com/srltas/runtogether/application/GroupServiceTest.java
+++ b/src/test/java/com/srltas/runtogether/application/GroupServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.srltas.runtogether.application.port.in.AddGroupCommand;
+import com.srltas.runtogether.application.port.in.DeleteGroupCommand;
 import com.srltas.runtogether.domain.model.group.Group;
 import com.srltas.runtogether.domain.model.group.GroupCreationService;
 import com.srltas.runtogether.domain.model.group.GroupRepository;
@@ -85,5 +86,16 @@ class GroupServiceTest {
 			.isInstanceOf(NeighborhoodNotRegisteredException.class);
 
 		verifyNoMoreInteractions(groupRepository);
+	}
+
+	@Test
+	@DisplayName("그룹 삭제 성공")
+	void delete_whenValidCommand_thenDeletesGroup() {
+		String groupId = TestIdGenerator.generateGroupId();
+		DeleteGroupCommand command = new DeleteGroupCommand(groupId);
+
+		groupService.delete(command);
+
+		verify(groupRepository).delete(groupId);
 	}
 }


### PR DESCRIPTION
## 📌 Summary
러닝 그룹 삭제 기능에 대한 Service 계층을 구현합니다.

## 📝 Description
- DeleteGroup 인터페이스 추가 및 기능 구현
- 그룹 삭제에 대한 테스트 코드 작성

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
