### PR TITLE
[#100] 러닝 그룹 삭제 Controller 계층 구현

### DIFF
--- a/src/main/java/com/srltas/runtogether/adapter/in/GroupController.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/GroupController.java
@@ -4,15 +4,19 @@ import static com.srltas.runtogether.adapter.in.web.common.SessionUtils.*;
 import static com.srltas.runtogether.adapter.in.web.common.UrlConstants.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.srltas.runtogether.adapter.in.web.dto.AddGroupRequest;
+import com.srltas.runtogether.adapter.in.web.dto.DeleteGroupRequest;
 import com.srltas.runtogether.adapter.out.session.UserSession;
 import com.srltas.runtogether.application.port.in.AddGroup;
 import com.srltas.runtogether.application.port.in.AddGroupCommand;
+import com.srltas.runtogether.application.port.in.DeleteGroup;
+import com.srltas.runtogether.application.port.in.DeleteGroupCommand;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,12 +30,13 @@ import lombok.RequiredArgsConstructor;
 public class GroupController {
 
 	private final AddGroup addGroup;
+	private final DeleteGroup deleteGroup;
 
 	@Operation(
-		summary = "그룹 생성",
-		description = "내 동네에 그룹을 생성합니다."
+		summary = "러닝 그룹 생성",
+		description = "내 동네에 러닝 그룹을 생성합니다."
 	)
-	@ApiResponse(responseCode = "200", description = "그룹 생성 성공")
+	@ApiResponse(responseCode = "200", description = "러닝 그룹 생성 성공")
 	@PostMapping
 	public ResponseEntity<Void> create(
 		@RequestBody @Valid AddGroupRequest request, HttpSession session) {
@@ -41,6 +46,17 @@ public class GroupController {
 			request.groupDescription(),
 			request.neighborhoodId(),
 			userSession.userId()));
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(
+		summary = "러닝 그룹 삭제",
+		description = "내 동네에 생성한 러닝 그룹을 삭제합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "러닝 그룹 삭제 성공")
+	@DeleteMapping
+	public ResponseEntity<Void> delete(@RequestBody @Valid DeleteGroupRequest request) {
+		deleteGroup.delete(new DeleteGroupCommand(request.groupId()));
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/srltas/runtogether/adapter/in/web/dto/DeleteGroupRequest.java
+++ b/src/main/java/com/srltas/runtogether/adapter/in/web/dto/DeleteGroupRequest.java
@@ -1,0 +1,10 @@
+package com.srltas.runtogether.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteGroupRequest(
+
+	@NotNull(message = "그룹 ID는 필수입니다.")
+	String groupId
+) {
+}

--- a/src/test/java/com/srltas/runtogether/adapter/in/GroupControllerTest.java
+++ b/src/test/java/com/srltas/runtogether/adapter/in/GroupControllerTest.java
@@ -16,9 +16,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import com.srltas.runtogether.adapter.in.web.dto.AddGroupRequest;
+import com.srltas.runtogether.adapter.in.web.dto.DeleteGroupRequest;
 import com.srltas.runtogether.adapter.out.session.UserSession;
 import com.srltas.runtogether.application.port.in.AddGroup;
 import com.srltas.runtogether.application.port.in.AddGroupCommand;
+import com.srltas.runtogether.application.port.in.DeleteGroup;
+import com.srltas.runtogether.application.port.in.DeleteGroupCommand;
 
 import jakarta.servlet.http.HttpSession;
 
@@ -29,13 +32,16 @@ class GroupControllerTest {
 	private AddGroup addGroup;
 
 	@Mock
+	private DeleteGroup deleteGroup;
+
+	@Mock
 	HttpSession session;
 
 	@InjectMocks
 	private GroupController groupController;
 
 	@Test
-	@DisplayName("그룹 생성 성공")
+	@DisplayName("러닝 그룹 생성 성공")
 	void testAddGroupSuccess() {
 		String userId = generateUserId();
 		String neighborhoodId = generateNeighborhoodId();
@@ -50,5 +56,18 @@ class GroupControllerTest {
 		assertThat(response.getStatusCode(), is(HttpStatus.OK));
 		verify(addGroup).create(
 			new AddGroupCommand("Test Group", "Test Group Description", neighborhoodId, userId));
+	}
+
+	@Test
+	@DisplayName("러닝 그룹 삭제 성공")
+	void testDeleteGroupSuccess() {
+		String groupId = generateUserId();
+
+		DeleteGroupRequest request = new DeleteGroupRequest(groupId);
+
+		ResponseEntity<Void> response = groupController.delete(request);
+
+		assertThat(response.getStatusCode(), is(HttpStatus.OK));
+		verify(deleteGroup).delete(new DeleteGroupCommand(groupId));
 	}
 }


### PR DESCRIPTION
## 📌 Summary
러닝 그룹 삭제 기능에 대한 Controller 계층을 구현합니다.

## 📝 Description
**API**
- 메서드: DELETE
- 콘텐츠 유형: application/json
- 엔드포인트: /groups
- 러닝 그룹 삭제를 위해 `그룹ID`을 요청에 받습니다.

## ✅ Checklist
- [x] 새로운 기능이나 수정된 기능에 대해 충분한 테스트를 작성했습니다.
- [x] 코딩 스타일 가이드를 준수했습니다.
- [x] 문서(주석, README 등)가 필요하다면 업데이트했습니다.
